### PR TITLE
Add automatic website deployment via Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # Unwanted files
 amethyst
-Cargo.lock
 build
+Cargo.lock
 cobalt.rs
 target
 
 # Backup files
 .DS_Store
-thumbs.db
 *~
 *.rs.bk
 *.swp
+thumbs.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: rust
+
+rust:
+    - stable
+
+script:
+    - cargo install mdbook
+    - ./generate.sh
+
+sudo: true
+
+after_success: |
+    [ $TRAVIS_BRANCH = master ] &&
+    [ $TRAVIS_PULL_REQUEST = false ] &&
+    sudo pip install ghp-import &&
+    ghp-import -n build/ &&
+    git config user.name "Travis CI Worker" &&
+    git config user.email "ebkalderon@gmail.com" &&
+    git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rust:
 script:
     - cargo install mdbook
     - ./generate.sh
+    - touch build/.nojekyll
+    - echo "www.amethyst.rs" > build/CNAME
 
 sudo: true
 

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.amethyst.rs


### PR DESCRIPTION
This pull request mimics the functionality present in the original _ebkalderon.github.io/amethyst_ website. It is untested as of yet, so some manual commits to `master` may be needed if everything goes wrong after merging this.
