### PR TITLE
Add Gitter sidecar chat box

### DIFF
--- a/src/_layouts/default.tpl
+++ b/src/_layouts/default.tpl
@@ -40,8 +40,6 @@
 
         {{ content }}
 
-
-
       </div>
     </div>
 
@@ -49,6 +47,13 @@
       <!-- privacy stuff, back to top? -->
       <p class="license">This website and the Amethyst logo are licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 License.</a></p>
     </div>
+
+  <script>
+    ((window.gitter = {}).chat = {}).options = {
+        room: 'ebkalderon/amethyst'
+    };
+  </script>
+  <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
 
   </body>
 </html>

--- a/src/css/cover.css
+++ b/src/css/cover.css
@@ -65,6 +65,7 @@ body {
   text-align: center;
   text-shadow: none;
 }
+
 hr {
   border: 0;
   height: 1px;
@@ -155,6 +156,7 @@ hr {
   -ms-transition: color .25s ease-out;
   transition: color .25s ease-out;
 }
+
 .masthead-nav > li > a:hover,
 .masthead-nav > li > a:focus {
   background-color: transparent;
@@ -217,7 +219,6 @@ hr {
   background-size: 100% 100%;
   background-repeat: no-repeat;
   background-position: 0%;
-
   box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, .15) inset, 0px -2px 5px 0px rgba(0, 0, 0, .15) inset;
 }
 
@@ -226,6 +227,7 @@ hr {
   padding: 3em 0;
   text-shadow: #000 0px 0px 15px;
 }
+
 .cover .btn-lg {
   padding: 10px 20px;
   font-weight: bold;
@@ -263,8 +265,6 @@ hr {
 .license > a:hover {
   color: #C28BF9;
 }
-
-
 
 /*
  * Affix and center
@@ -310,4 +310,25 @@ hr {
   .masthead-nav > li {
     float: left;
   }
+}
+
+/*
+ * Gitter Sidecar button
+ */
+
+.gitter-open-chat-button,
+.gitter-open-chat-button:visited {
+  color: #FFFFFF;
+  background-color: #867CC8;
+  //background-color: #685CBB;
+  font-family: "Raleway", sans-serif;
+  padding-top: 9px;
+  padding-bottom: 7px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.gitter-open-chat-button:focus,
+.gitter-open-chat-button:hover {
+    background-color: #685CBB;
 }


### PR DESCRIPTION
This button at the bottom-left of the page expands into a sidebar showcasing the Gitter chat. See the [Sidecar website](https://sidecar.gitter.im/) for details. Visual appearance is shown in the attached screenshot:

![screenshot from 2016-03-22 03-53-56](https://cloud.githubusercontent.com/assets/322831/13945194/cb130aae-efe1-11e5-8c8d-abeb4b2cfdc0.png)
