### PR TITLE
Add RSS support for cobalt blog

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -26,4 +26,4 @@ git reset --hard f8c6034 # This keeps it on the current version, it can be updat
 cargo build --release
 cd ..
 
-./cobalt.rs/target/release/cobalt build -s src -d ./build
+./cobalt.rs/target/release/cobalt build -s src -d ./build --config src/.cobalt.yml

--- a/src/.cobalt.yml
+++ b/src/.cobalt.yml
@@ -1,0 +1,4 @@
+rss: rss.xml
+name: Amethyst
+description: Everything should be made as simple as possible, but no simpler.
+link: blog.amethyst.rs


### PR DESCRIPTION
This PR adds simple RSS feed via a `rss.xml` file that is located at `amethyst.rs/rss.xml` for a simple RSS feed. This is connected to issue [#27](https://github.com/ebkalderon/amethyst/issues/27).
