### PR TITLE
Use mainline version of Cobalt.rs

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -23,7 +23,7 @@ cp -r amethyst/target/doc/ build/doc
 #echo '<meta http-equiv="refresh" content="0; url=amethyst/" />' > web/doc/index.html
 
 echo "Building website from source..."
-git clone https://github.com/johannhof/cobalt.rs
+git clone https://github.com/cobalt-org/cobalt.rs
 cd cobalt.rs
 cargo build --release
 cd ..


### PR DESCRIPTION
Looks like cobalt-org/cobalt.rs#64 has been merged on the mainline version of Cobalt, so let's switch back to it.
