### PR TITLE
Use newest version of mdBook for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ amethyst
 build
 Cargo.lock
 cobalt.rs
+mdBook
 target
 
 # Backup files

--- a/generate.sh
+++ b/generate.sh
@@ -15,6 +15,7 @@ cd ..
 echo "Generating book..."
 git clone https://github.com/azerupi/mdBook
 cd mdBook
+git reset --hard 925939e26720e1998796a1735c296048c99ee7f8
 cargo build --release
 cd ..
 ./mdBook/target/release/mdbook build amethyst/book

--- a/generate.sh
+++ b/generate.sh
@@ -10,11 +10,14 @@ echo "Generating API docs..."
 git clone https://github.com/ebkalderon/amethyst
 cd amethyst
 cargo doc --no-deps -p amethyst -p amethyst_engine
+cd ..
 
 echo "Generating book..."
-cargo install mdbook
-mdbook build book
+git clone https://github.com/azerupi/mdBook
+cd mdBook
+cargo build --release
 cd ..
+./mdBook/target/release/mdbook build amethyst/book
 
 echo "Copying files over..."
 cp -r amethyst/book/html/ build/book


### PR DESCRIPTION
This should fix the HTTPS issues with fonts we've been having since switching to CloudFlare. These changes should remain in place until a new version of mdBook is published on Crates.io with [at least this commit](https://github.com/azerupi/mdBook/commit/925939e26720e1998796a1735c296048c99ee7f8).
