### PR TITLE
Fix outdated vision link

### DIFF
--- a/src/index.liquid
+++ b/src/index.liquid
@@ -5,7 +5,7 @@ extends: default.liquid
     <h1 class="cover-heading">Vision</h1>
     <p class="lead">Amethyst aims to be a fast, data-oriented, and data-driven game engine suitable for rapid prototyping and iteration.</p>
     <p class="lead">
-      <a href="https://github.com/ebkalderon/amethyst#vision" class="btn btn-lg btn-default">Learn more</a>
+      <a href="https://github.com/amethyst/amethyst#vision" class="btn btn-lg btn-default">Learn more</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Previously pointed to my personal account (`ebkalderon/amethyst`). Changed to point to the current location (`amethyst/amethyst`).
