### PR TITLE
Show all posts until pagination is added

### DIFF
--- a/src/index.liquid
+++ b/src/index.liquid
@@ -14,7 +14,7 @@ extends: default.liquid
   <h2>What's new?</h2>
   <!--<br />-->
   <div class="blog-post-body">
-    {% for post in posts limit:3 %}
+    {% for post in posts %}
       <div class="blog-post">
         <h4 class="blog-post-date {{post.title}}"></h4>
         <h4 class="blog-post-link"><a href="{{post.path}}">{{ post.title }}</a></h4>


### PR DESCRIPTION
Eventually, we will need to either add in a dedicated _Blog_ page or at least pagination on the homepage. Since we currently have neither, we should remove this arbitrary limit for now so that people can at least read all the _TWIA_ articles.
