### PR TITLE
Use docs.rs for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ Content                              | Source Path               | Website Path
 Main Content                         | `src/`                    | `/`
 Newsletter (*This Week In Amethyst*) | `src/posts/`             | `/posts/`
 Amethyst Book                        | [`amethyst/book/src`][bs] | `/book/`
-Generated API Documentation          | [`amethyst/src/`][ds]     | `/doc/`
 
 [bs]: https://github.com/ebkalderon/amethyst/tree/master/book/src
-[ds]: https://github.com/ebkalderon/amethyst/tree/master/src
 
 ## Building Locally
 

--- a/generate.sh
+++ b/generate.sh
@@ -6,19 +6,6 @@ echo "Cleaning up workspace..."
 rm -rf build amethyst cobalt.rs
 mkdir build
 
-echo "Generating API docs..."
-echo "  Generating master branch docs"
-git clone https://github.com/amethyst/amethyst --branch master
-cd amethyst
-  cargo doc --no-deps -p amethyst -p amethyst_config -p amethyst_renderer
-cd ..
-
-echo "  Generating develop branch docs"
-git clone -b develop https://github.com/amethyst/amethyst amethyst_dev
-cd amethyst_dev
-  cargo doc --no-deps -p amethyst -p amethyst_config -p amethyst_renderer
-cd ..
-
 echo "Compiling the book..."
 cargo install mdbook
 mdbook build amethyst/book
@@ -27,9 +14,6 @@ echo "Copying files over..."
 cp -r amethyst/book/html/ build/book
 cp -r amethyst/book/images/ build/book/images
 
-mkdir -p build/doc
-cp -r amethyst/target/doc/ build/doc/master
-cp -r amethyst_dev/target/doc build/doc/develop
 #echo '<meta http-equiv="refresh" content="0; url=amethyst/" />' > web/doc/index.html
 
 echo "Building website from source..."

--- a/src/_layouts/default.liquid
+++ b/src/_layouts/default.liquid
@@ -55,7 +55,7 @@
               <ul class="nav masthead-nav">
                 <li id="home" class="active"><a href="/">Home<hr /></a></li>
                 <li id="book" ><a href="/book">Book<hr /></a></li>
-                <li id="doc"><a href="/doc">Docs<hr /></a></li>
+                <li id="doc"><a href="https://docs.rs/amethyst/">Docs<hr /></a></li>
                 <li id="github"><a href="https://github.com/amethyst">GitHub<hr /></a></li>
               </ul>
             </nav>

--- a/src/doc/index.liquid
+++ b/src/doc/index.liquid
@@ -1,9 +1,0 @@
-extends: default.liquid
----
-<a href="/doc/master/amethyst/index.html">master</a>
-<br />
-<a href="/doc/develop/amethyst/index.html">develop</a>
-<script>
-$('li.active').removeClass('active');
-$('li#doc').addClass('active');
-</script>


### PR DESCRIPTION
It's much easier to just refer to docs.rs rather than trying to keep these up to date ourselves.  This way we require less coordination between the website team and the engine team.