### PR TITLE
Improve build speeds by caching cargo data and removing sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,20 @@ language: rust
 rust:
     - stable
 
+# Force third-party crates to persist from previous builds and update only when
+# needed.
+cache: cargo
+
+# This improves the boot time of the machine
+sudo: false
+
+# Install ALSA development libraries before compiling on Linux.
+addons:
+  apt:
+    packages:
+      - libasound2-dev
+
 before_install:
-    - sudo apt-get install libasound2-dev
     - gem install jekyll
     - gem install jekyll-feed
 
@@ -18,7 +30,7 @@ script:
 after_success: |
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    sudo pip install ghp-import &&
+    pip install ghp-import &&
     ghp-import -n build/ &&
     git config user.name "Travis CI Worker" &&
     git config user.email "name@example.com" &&


### PR DESCRIPTION
Builds take quite some time because no cargo cache is stored.  This should help.

Using sudo also makes the boot take longer because travis has to spin up a whole VM instead of a container.