### PR TITLE
Switch to nightly for builds to work around doc issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: rust
 
 rust:
-    - stable
+    - nightly
 
 branches:
   only:


### PR DESCRIPTION
Currently, in the `nalgebra` crate there is an issue when documenting
the crate that fails on 1.31.1. The fix is currently on nightly so
switching to that for building the docs makes sense.