### PR TITLE
Added contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Amethyst's Website
+
+Thank you for your interest in contributing! There are many ways to
+contribute, and we appreciate all of them. 
+
+If you have questions, please make a post on [our forums][fm] or
+hop on our Discord's [#website][dc] channel.
+
+As a reminder, all contributors are expected to follow the Amethyst [Code of Conduct][coc].
+
+## Bug Reports
+[bug-reports]: #bug-reports
+
+If you have the chance, before reporting a bug, please [search existing
+issues](https://github.com/amethyst/website/search?q=&type=Issues&utf8=%E2%9C%93),
+as it's possible that someone else has already reported your error. This doesn't
+always work, and sometimes it's hard to know what to search for, so consider this
+extra credit. We won't mind if you accidentally file a duplicate report.
+
+Opening an issue is as easy as following [this
+link](https://github.com/amethyst/website/issues/new) and filling out the fields.
+
+*These contributing guidelines are adapted from the Rust repository, which is available here: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md*
+
+
+
+[fm]: https://community.amethyst-engine.org
+[dc]: http://discord.gg/amethyst
+[coc]: https://github.com/amethyst/amethyst/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
This fixes #123 

I used Rust's contributing file as a guideline, but 80% of it was unrelated so I modified it a bit to just highlight issue tracking.